### PR TITLE
added font import because gatsby keeps rebuilding html file

### DIFF
--- a/src/theme/GlobalStyles.ts
+++ b/src/theme/GlobalStyles.ts
@@ -1,6 +1,7 @@
 import { createGlobalStyle } from "styled-components";
 
 export default createGlobalStyle`
+  @import url('https://fonts.googleapis.com/css?family=Lato:400,700|Roboto:400,700|Saira+Extra+Condensed:400,700');
   *, ::before, ::after {
     box-sizing: border-box;
     margin: 0;


### PR DESCRIPTION
Gatsby kept rebuilding the HTML file which removed the `link` to the Google Fonts. Importing directly to the GlobalStyles looks to be the recommended way to solve this.